### PR TITLE
Fix rounding in bitrate column

### DIFF
--- a/src/renderer/components/LandingPage/DirectoryListing.vue
+++ b/src/renderer/components/LandingPage/DirectoryListing.vue
@@ -184,7 +184,7 @@ export default {
                       album: (album !== null) ? album : '',
                       trackNo: (trackNo !== null) ? trackNo : 0,
                       format: fileTypeInfo.ext,
-                      bitrate: (bitrate !== null) ? bitrate / 1000 + 'kbps' : '-',
+                      bitrate: (bitrate !== null) ? Math.round(bitrate / 1000) + 'kbps' : '-',
                       codec: (codec !== null) ? codec : ''
                     })
                   })


### PR DESCRIPTION
A pretty simple cosmetic fix for the rounding column caused by some of my FLAC files.

Before:
<img width="632" alt="before" src="https://user-images.githubusercontent.com/5890747/77202588-897e4e80-6ae6-11ea-8edc-e648a583c81e.PNG">

After:
<img width="634" alt="after" src="https://user-images.githubusercontent.com/5890747/77202646-a31f9600-6ae6-11ea-9203-1ffdf813fd0a.PNG">

Cheers! 😄 