### PR TITLE
Use the file path when a file has no title

### DIFF
--- a/src/renderer/components/LandingPage/DirectoryListing.vue
+++ b/src/renderer/components/LandingPage/DirectoryListing.vue
@@ -187,7 +187,7 @@ export default {
                     // console.log(metadata)
                     // Get data for file object
                     let artist = (metadata.common.artist !== undefined) ? metadata.common.artist : 'No Artist'
-                    let title = (metadata.common.title !== undefined) ? metadata.common.title : 'Untitled'
+                    let title = (metadata.common.title !== undefined) ? metadata.common.title : filePath
                     let album = (metadata.common.album !== undefined) ? metadata.common.album : '-'
                     let bitrate = (metadata.format.bitrate !== undefined) ? metadata.format.bitrate : ''
                     let codec = (metadata.format.codec !== undefined) ? metadata.format.codec.replace('MPEG 1 Layer 3', 'MP3') : ''


### PR DESCRIPTION
If a file has no valid title (for instance, if it's a basic WAV file or something metadata can't parse), fall back to using the file's name instead of "Untitled"