### PR TITLE
Title tweaks

### DIFF
--- a/src/renderer/components/LandingPage.vue
+++ b/src/renderer/components/LandingPage.vue
@@ -1,6 +1,6 @@
 <template>
   <div id="wrapper" class="p-3">
-    
+
     <b-modal @ok="saveSettings" ref="settings-modal" title="Settings">
       <b-form-group label="Transfer Mode:">
         <b-form-radio v-model="conversionMode" name="mode-sp" value="SP">SP (Best quality)</b-form-radio>
@@ -12,10 +12,13 @@
       <b>Title Format</b>
       <p>Options: <b-badge>%title%</b-badge> <b-badge>%artist%</b-badge> <b-badge>%trackno%</b-badge></p>
       <b-form-input v-model="titleFormat"></b-form-input>
+      <br>
+      <b-form-checkbox type="checkbox" name="sonicstage-titles" id="sonicstage-titles" v-model="sonicStageNosStrip" value="true">
+      <label for="sonicstage-titles">Strip SonicStage track numbers from titles (e.g 001-Title) {{ sonicStageNosStrip }}</label>
       <hr />
       <b-button variant="outline-primary" @click="showDebugConsole">Debug Window</b-button>
     </b-modal>
-    
+
     <b-container fluid>
       <b-row>
         <b-col cols="6"><img id="logo" src="~@/assets/logo.svg" alt="Platinum MD" class="p-3"></b-col>
@@ -23,7 +26,7 @@
         <b-col class="text-right p-3"><b-button variant="outline-light" @click="showSettingsModal">Settings <font-awesome-icon icon="cog"></font-awesome-icon></b-button></b-col>
       </b-row>
     </b-container>
-    
+
     <b-container fluid class="p-3">
       <b-row>
         <b-col class="white-bg full-height mx-3 p-0 overflow-auto">
@@ -70,6 +73,7 @@
       saveSettings: function () {
         store.set('conversionMode', this.conversionMode)
         store.set('titleFormat', this.titleFormat)
+        store.set('sonicStageNosStrip', this.sonicStageNosStrip)
         bus.$emit('config-update')
       },
       /**
@@ -80,7 +84,10 @@
           this.conversionMode = store.get('conversionMode')
         }
         if (store.has('titleFormat')) {
-          this.conversionMode = store.get('titleFormat')
+          this.titleFormat = store.get('titleFormat')
+        }
+        if (store.has('sonicStageNosStrip')) {
+          this.sonicStageNosStrip = store.get('sonicStageNosStrip')
         }
       },
       /**

--- a/src/renderer/components/LandingPage.vue
+++ b/src/renderer/components/LandingPage.vue
@@ -13,8 +13,8 @@
       <p>Options: <b-badge>%title%</b-badge> <b-badge>%artist%</b-badge> <b-badge>%trackno%</b-badge></p>
       <b-form-input v-model="titleFormat"></b-form-input>
       <br>
-      <b-form-checkbox type="checkbox" name="sonicstage-titles" id="sonicstage-titles" v-model="sonicStageNosStrip" value="true">
-      <label for="sonicstage-titles">Strip SonicStage track numbers from titles (e.g 001-Title) {{ sonicStageNosStrip }}</label>
+      <b-form-checkbox type="checkbox" name="sonicstage-titles" id="sonicstage-titles" v-model="sonicStageNosStrip">
+      <label for="sonicstage-titles">Strip SonicStage track numbers from titles (e.g 001-Title)</label>
       <hr />
       <b-button variant="outline-primary" @click="showDebugConsole">Debug Window</b-button>
     </b-modal>
@@ -54,7 +54,8 @@
     data () {
       return {
         conversionMode: 'SP',
-        titleFormat: '%title% - %artist%'
+        titleFormat: '%title% - %artist%',
+        sonicStageNosStrip: true
       }
     },
     created () {
@@ -84,7 +85,7 @@
           this.conversionMode = store.get('conversionMode')
         }
         if (store.has('titleFormat')) {
-          this.titleFormat = store.get('titleFormat')
+          this.conversionMode = store.get('titleFormat')
         }
         if (store.has('sonicStageNosStrip')) {
           this.sonicStageNosStrip = store.get('sonicStageNosStrip')

--- a/src/renderer/components/LandingPage/DirectoryListing.vue
+++ b/src/renderer/components/LandingPage/DirectoryListing.vue
@@ -259,8 +259,7 @@ export default {
         }
         // Convert to desired format
         let finalFile = await this.convert(fileName, this.selected[i])
-        let artistname = (this.selected[i].artist !== 'No Artist') ? ' - ' + this.selected[i].artist : ''
-        let trackTitle = this.selected[i].title + artistname
+        let trackTitle = (this.selected[i].artist !== 'No Artist') ? this.selected[i].title + ' - ' + this.selected[i].artist : this.selected[i].title
         console.log('Conversion Complete.')
         await this.sendToPlayer(finalFile, trackTitle)
         bus.$emit('netmd-status', { eventType: 'transfer-completed' })

--- a/src/renderer/components/LandingPage/DirectoryListing.vue
+++ b/src/renderer/components/LandingPage/DirectoryListing.vue
@@ -34,7 +34,7 @@
           <b-button variant="outline-light" @click="readDirectory" :disabled="isBusy"><font-awesome-icon icon="sync-alt"></font-awesome-icon></b-button>
         </b-col>
         <b-col>
-          <b>{{ selected.length }}</b> tracks selected {{ conversionMode }}<br />
+          <b>{{ selected.length }}</b> tracks selected {{ conversionMode }} strip {{ sonicStageNosStrip }}<br />
           <b-spinner small varient="success" label="Small Spinner" v-if="progress != 'Idle'"></b-spinner> <span v-if="progress"><b-badge class="text-uppercase"><span v-if="progress != 'Idle'">{{ processing }} - {{ selected.length }} / </span>Status: {{ progress }}</b-badge></span>
         </b-col>
         <b-col class="text-right">
@@ -129,6 +129,7 @@ export default {
       config: {},
       conversionMode: 'SP',
       titleFormat: '%title% - %artist%',
+      sonicStageNosStrip: 'true',
       bitrate: 128,
       selectedTrack: {
         trackNo: 0
@@ -191,8 +192,8 @@ export default {
                 .then(metadata => {
                   // console.log(metadata)
                   // Get data for file object
+                  let title = (metadata.common.title !== undefined) ? metadata.common.title : (this.sonicStageNosStrip === 'true') ? path.parse(filePath).name.replace(RegExp(/^\d\d\d-/), '') : path.parse(filePath).name
                   let artist = (metadata.common.artist !== undefined) ? metadata.common.artist : 'No Artist'
-                  let title = (metadata.common.title !== undefined) ? metadata.common.title : path.parse(filePath).name
                   let album = (metadata.common.album !== undefined) ? metadata.common.album : '-'
                   let bitrate = (metadata.format.bitrate !== undefined) ? metadata.format.bitrate : ''
                   let codec = (metadata.format.codec !== undefined) ? metadata.format.codec.replace(/^MPEG [12] Layer 3$/, 'MP3') : ''
@@ -479,6 +480,9 @@ export default {
       }
       if (store.has('conversionMode')) {
         this.conversionMode = store.get('conversionMode')
+      }
+      if (store.has('sonicStageNosStrip')) {
+        this.sonicStageNosStrip = store.get('sonicStageNosStrip')
       }
     }
   }

--- a/src/renderer/components/LandingPage/DirectoryListing.vue
+++ b/src/renderer/components/LandingPage/DirectoryListing.vue
@@ -34,7 +34,7 @@
           <b-button variant="outline-light" @click="readDirectory" :disabled="isBusy"><font-awesome-icon icon="sync-alt"></font-awesome-icon></b-button>
         </b-col>
         <b-col>
-          <b>{{ selected.length }}</b> tracks selected {{ conversionMode }} strip {{ sonicStageNosStrip }}<br />
+          <b>{{ selected.length }}</b> tracks selected {{ conversionMode }}<br />
           <b-spinner small varient="success" label="Small Spinner" v-if="progress != 'Idle'"></b-spinner> <span v-if="progress"><b-badge class="text-uppercase"><span v-if="progress != 'Idle'">{{ processing }} - {{ selected.length }} / </span>Status: {{ progress }}</b-badge></span>
         </b-col>
         <b-col class="text-right">
@@ -192,7 +192,7 @@ export default {
                 .then(metadata => {
                   // console.log(metadata)
                   // Get data for file object
-                  let title = (metadata.common.title !== undefined) ? metadata.common.title : (this.sonicStageNosStrip === 'true') ? path.parse(filePath).name.replace(RegExp(/^\d\d\d-/), '') : path.parse(filePath).name
+                  let title = (metadata.common.title !== undefined) ? metadata.common.title : (this.sonicStageNosStrip === true) ? path.parse(filePath).name.replace(RegExp(/^\d\d\d-/), '') : path.parse(filePath).name
                   let artist = (metadata.common.artist !== undefined) ? metadata.common.artist : 'No Artist'
                   let album = (metadata.common.album !== undefined) ? metadata.common.album : '-'
                   let bitrate = (metadata.format.bitrate !== undefined) ? metadata.format.bitrate : ''

--- a/src/renderer/components/LandingPage/DirectoryListing.vue
+++ b/src/renderer/components/LandingPage/DirectoryListing.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-  
+
     <b-modal @ok="editTrack" ref="edit-track" title="Edit Track">
       <b-row class="my-1">
         <b-col sm="2">
@@ -27,7 +27,7 @@
         </b-col>
       </b-row>
     </b-modal>
-    
+
     <b-container class="toolbar py-2 m-0 sticky-top">
       <b-row align-v="center">
         <b-col cols="1">
@@ -43,7 +43,7 @@
         </b-col>
       </b-row>
     </b-container>
-    
+
     <b-table
       selectable
       striped
@@ -60,19 +60,19 @@
         <b-spinner class="align-middle"></b-spinner>
         <strong>Loading...</strong>
       </div>
-      
+
       <template v-slot:cell(trackNo)="data">
         <div>
           <h5 class="mb-0"><b-badge>{{ data.item.trackNo }}</b-badge></h5>
         </div>
       </template>
-      
+
       <template v-slot:cell(bitrate)="data">
         <div class="text-right">
           <b-badge variant="success" class="text-uppercase">{{ data.item.bitrate }} {{ data.item.codec }}</b-badge>
         </div>
       </template>
-      
+
       <template v-slot:cell(time)="data">
         <div class="text-right">
           {{ data.item.time | timeFormat }}
@@ -84,9 +84,9 @@
           <a @click="showEditModal(data.item)"><font-awesome-icon icon="edit"></font-awesome-icon></a>
         </div>
       </template>
-      
+
     </b-table>
- 
+
   </div>
 </template>
 
@@ -192,7 +192,7 @@ export default {
                   // console.log(metadata)
                   // Get data for file object
                   let artist = (metadata.common.artist !== undefined) ? metadata.common.artist : 'No Artist'
-                  let title = (metadata.common.title !== undefined) ? metadata.common.title : filePath
+                  let title = (metadata.common.title !== undefined) ? metadata.common.title : path.parse(filePath).name
                   let album = (metadata.common.album !== undefined) ? metadata.common.album : '-'
                   let bitrate = (metadata.format.bitrate !== undefined) ? metadata.format.bitrate : ''
                   let codec = (metadata.format.codec !== undefined) ? metadata.format.codec.replace(/^MPEG [12] Layer 3$/, 'MP3') : ''
@@ -259,7 +259,8 @@ export default {
         }
         // Convert to desired format
         let finalFile = await this.convert(fileName, this.selected[i])
-        let trackTitle = this.selected[i].title + ' - ' + this.selected[i].artist
+        let artistname = (this.selected[i].artist !== 'No Artist') ? ' - ' + this.selected[i].artist : ''
+        let trackTitle = this.selected[i].title + artistname
         console.log('Conversion Complete.')
         await this.sendToPlayer(finalFile, trackTitle)
         bus.$emit('netmd-status', { eventType: 'transfer-completed' })


### PR DESCRIPTION
Four improvements:
- Fixes bug on windows when loading files without metadata (such as .wav) where the filename was not populated into the song title.
- Strips the file extension when using filename as title.
- If the artist metadata is not set, does not write '- No Artist' into the title of the track on the disk.
- Added settings checkbox to strip the SonicStage track numbers from track title, when using the filename as title (useful when uploading .wavs that SonicStage has downloaded from a different MD using a RH1)