### PR TITLE
added missing dependencies to brew install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/gavinbenda/platinum-md.svg?branch=master)](https://travis-ci.org/gavinbenda/platinum-md) 
+[![Build Status](https://travis-ci.org/gavinbenda/platinum-md.svg?branch=master)](https://travis-ci.org/gavinbenda/platinum-md)
 
 # Platinum-MD
 
@@ -17,7 +17,7 @@ You will need to install homebrew: https://docs.brew.sh/Installation
 
 Then install the following:
 
-`brew install --force pkg-config qt5 mad libid3tag libtag glib libusb libusb-compat libgcrypt ffmpeg && brew link --force qt5`
+`brew install --force pkg-config qt5 mad libid3tag libtag glib libusb libusb-compat libgcrypt ffmpeg json-c && brew link --force qt5`
 
 ##### Windows
 
@@ -113,4 +113,3 @@ The ATRAC Encoder by @dcherednik
 I do this as a personal project, and a few people have expressed interested in donating to keep the project going, this will simply go back into buying test hardware and/or possibly coffee.
 
 [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=XVS44CZYFPCJJ)
-


### PR DESCRIPTION
platinum MD was hanging on `Negotiating with device` on OSX 10.15.6, this was caused by failure of the netmdcli tool:
```
$ ./netmdcli 
dyld: Library not loaded: /usr/local/opt/json-c/lib/libjson-c.5.dylib
  Referenced from: /Users/Doug/workspace/platinum-md/resources/mac/bin/./netmdcli
  Reason: image not found
```

installing json-c resolved this issue:
```
$ brew install json-c
==> Downloading https://homebrew.bintray.com/bottles/json-c-0.15.catalina.bottle.tar.gz
######################################################################## 100.0%
==> Pouring json-c-0.15.catalina.bottle.tar.gz
  /usr/local/Cellar/json-c/0.15: 32 files, 276.9KB
$ ./netmdcli 
{
  "device":"Net MD\/Hi-MD",
  "title":"<Untitled>",
  "recordedTime":"00:11:11.49",
  "totalTime":"01:20:59.08",
  "availableTime":"01:09:38.57",
  "tracks":[
    {
      "no":0,
      "protect":"UnPROT",
      "bitrate":"UNKNOWN",
      "time":"03:25:54",
      "name":"No Title"
    },
    {
      "no":1,
      "protect":"UnPROT",
      "bitrate":"UNKNOWN",
      "time":"04:06:03",
      "name":"No Title"
    },
    {
      "no":2,
      "protect":"UnPROT",
      "bitrate":"UNKNOWN",
      "time":"03:39:77",
      "name":"No Title"
    }
  ]
```