### PR TITLE
himd-use filename for track title if no metadata

### DIFF
--- a/src/renderer/common.js
+++ b/src/renderer/common.js
@@ -7,7 +7,7 @@ ffmpeg.setFfmpegPath(ffmpegPath)
   * Convert audio file to WAV file using ffmpeg
   * This MUST be 44100 and 16bit for the atrac encoder to work
   */
-export async function convertAudio (source, dest, format) {
+export async function convertAudio (source, dest, format, title = null) {
   return new Promise(async (resolve, reject) => {
     // Start conversion
     var codec = ['-acodec', 'pcm_s16le']
@@ -17,7 +17,11 @@ export async function convertAudio (source, dest, format) {
         codec = ['-acodec', 'flac']
         break
       case ('MP3'):
-        codec = ['-acodec', 'mp3', '-b:a', '256k', '-ar', '44100']
+        if (title !== null) {
+          codec = ['-metadata', 'title=' + title, '-acodec', 'mp3', '-b:a', '256k', '-ar', '44100']
+        } else {
+          codec = ['-acodec', 'mp3', '-b:a', '256k', '-ar', '44100']
+        }
         break
     }
     ffmpeg(source)

--- a/src/renderer/components/LandingPage/DirectoryListing.vue
+++ b/src/renderer/components/LandingPage/DirectoryListing.vue
@@ -227,7 +227,8 @@ export default {
                     format: fileTypeInfo.ext,
                     bitrate: (bitrate !== null) ? Math.round(bitrate / 1000) + 'kbps' : '-',
                     codec: (codec !== null) ? codec : '',
-                    time: time
+                    time: time,
+                    no_metadata: metadata.common.title
                   })
                 })
                 .catch(err => {
@@ -319,11 +320,14 @@ export default {
           // !SP and !LP, so must be hi-md - Convert to MP3
           finalFile = this.dir + this.tempDirectory + path.sep + fileName.replace(fileExtension, '.mp3')
           if (fileExtension.toLowerCase() === '.mp3') {
+            // file is already a mp3, no need to convert
             // Strip id3v2 tag because it can cause tracks to be unplayable on device
             await stripID3(sourceFile, finalFile)
           } else {
+            // file is not mp3
             this.progress = 'Converting to Mp3'
-            await convertAudio(sourceFile, finalFile, 'MP3')
+            let title = (selectedFile.no_metadata === undefined) ? selectedFile.title : null
+            await convertAudio(sourceFile, finalFile, 'MP3', title)
           }
         }
         resolve(finalFile)


### PR DESCRIPTION
Fixes `(null) - (null)` track info if no metadata is set in the source file when transfering to himd, by setting track title to be the filename during conversion to mp3.  