### PR TITLE
Fix title sanitization, path joining

### DIFF
--- a/src/renderer/common.js
+++ b/src/renderer/common.js
@@ -93,3 +93,10 @@ export function ensureDirSync (dirpath) {
     if (err.code !== 'EEXIST') throw err
   }
 }
+
+/**
+  *Sanitize titles for half-width slot
+  */
+export function sanitizeName (name) {
+  return name.normalize('NFD').replace(/[^\x20-\x7F]/g, '')
+}

--- a/src/renderer/components/LandingPage/NetMdListing.vue
+++ b/src/renderer/components/LandingPage/NetMdListing.vue
@@ -131,7 +131,7 @@
 <script>
 import bus from '@/bus'
 import { netmdcliPath, himdcliPath } from '@/binaries'
-import { convertAudio, ensureDirSync } from '@/common'
+import { convertAudio, ensureDirSync, sanitizeName } from '@/common'
 import { sonyVid, sharpVid, sonyMDPids, sonyHiMDPids, sharpPids } from '@/deviceIDs'
 import path from 'path'
 const checkDiskSpace = require('check-disk-space')
@@ -160,7 +160,7 @@ export default {
       newTrackPosition: 0,
       showOverlay: true,
       communicating: false,
-      downloadDir: homedir + path.sep + 'pmd-music' + path.sep,
+      downloadDir: path.join(homedir, 'pmd-music') + path.sep,
       downloadFormat: 'FLAC',
       download: false,
       useSonicStageNos: true,
@@ -428,6 +428,7 @@ export default {
       // this.progress = 'Renaming Track: ' + trackNo
       return new Promise((resolve, reject) => {
         trackNo = parseInt(this.renameTrackId, 10)
+        this.renameTrackName = sanitizeName(this.renameTrackName)
         console.log(trackNo + ':' + this.renameTrackName)
         let netmdcli = require('child_process').spawn(netmdcliPath, ['rename', trackNo, this.renameTrackName])
         netmdcli.on('close', (code) => {
@@ -453,6 +454,7 @@ export default {
     renameDisc: function () {
       return new Promise((resolve, reject) => {
         let title = this.info.title
+        title = sanitizeName(title)
         console.log(title)
         let netmdcli = require('child_process').spawn(netmdcliPath, ['settitle', title])
         netmdcli.on('close', (code) => {


### PR DESCRIPTION
As `netmdcli` doesn't sanitize input, title corruption and weird issues can occur (https://github.com/gavinbenda/platinum-md/issues/126, https://libredd.it/r/minidisc/comments/qsjy4f/platinummd_duplicating_tracks_any_fix/). This pull request aims to fix this. Unfortunately, despite my trying to add katakana support I couldn't as it is an issue with `netmdcli`. 
I also replaced path concatenation using ''+" with path.join (os.tmpdir() didn't return a trailing slash which made the program unusable).