### PR TITLE
Update latest macOS release link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 ##### OSX
 
-Download the [latest release](https://github.com/gavinbenda/platinum-md/releases/download/v1.1.0/platinum-md-1.1.0.dmg), and open the dmg.
+Download the [latest release](https://github.com/gavinbenda/platinum-md/releases/download/v1.2.1/platinum-md-1.2.1.dmg), and open the dmg.
 
 Drag the file to the applications folder.
 


### PR DESCRIPTION
The "latest release" for macOS link in the README still points to v1.1.0, I just fell for it and accidentally downloaded the old release. This PR fixes this.